### PR TITLE
Fix "Command contains quoted characters in flag names" error

### DIFF
--- a/src/commands/code-review.md
+++ b/src/commands/code-review.md
@@ -7,7 +7,7 @@ argument-hint: '[what to review] - e.g., "recent changes", "src/components", "*.
 # Code Review
 
 ## Current Repository State
-!`git status --short && echo "---" && git diff --stat && echo "---" && git log --oneline -5`
+!`git status --short && echo && git diff --stat && echo && git log --oneline -5`
 
 ## Pre-Review Analysis: Think This Through End-to-End
 


### PR DESCRIPTION
The `echo` arguments are misinterpreted as being flag names thus calling `/code-review` results in:

```
❯ /code-review                                                                                              
  ⎿  Error: Bash command permission check failed for pattern "!git status --short && echo "---" && git diff 
     --stat && echo "---" && git log --oneline -5": Command contains quoted characters in flag names 
```

By removing the arguments, we get an empty line separating the output of the other commands, and no errors are thrown in claudecode.