### PR TITLE
fix: set CI=true to prevent vitest hanging in watch mode

### DIFF
--- a/cli/hooks/utils.ts
+++ b/cli/hooks/utils.ts
@@ -171,8 +171,9 @@ export function getExecOptions(options: ExecAsyncOptions = {}, command?: string)
   const baseEnv = {
     ...processEnv,
     ...options.env,
-    // Ensure CI-like behavior for process cleanup
-    CI: process.env['CI'] ?? 'false',
+    // Ensure CI-like behavior for process cleanup — hooks run non-interactively,
+    // so CI=true prevents vitest from entering watch mode via TTY detection
+    CI: process.env['CI'] ?? 'true',
   };
   
   const baseOptions: ExecAsyncOptions = {


### PR DESCRIPTION
## Summary

Fixes #29

- Changes the `CI` env var fallback in `getExecOptions()` from `'false'` to `'true'`
- Hooks run non-interactively, so CI-like behavior is correct
- This prevents vitest from entering watch mode when executed via pseudo-TTY (e.g., Claude Code's Bash tool)

## Root cause

`CI: process.env['CI'] ?? 'false'` explicitly sets CI to the string "false" in non-CI environments. Combined with Claude Code's pseudo-TTY execution, vitest's detection logic (`!isCI && process.stdin.isTTY`) evaluates to `true`, entering watch mode. The `VITEST_WATCH` env var that was also set has no effect (vitest-dev/vitest#8459).

## Test plan

- [ ] Verify vitest exits after test completion when run via claudekit hooks
- [ ] Verify `CI` env var is still respected when explicitly set in the environment
- [ ] Verify non-test commands are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>