### PR TITLE
fix(file-guard): stop bypassing Claude Code permission prompts

### DIFF
--- a/cli/hooks/file-guard/index.ts
+++ b/cli/hooks/file-guard/index.ts
@@ -103,15 +103,12 @@ export class FileGuardHook extends BaseHook {
   }
 
   private allow(): HookResult {
-    return {
-      exitCode: 0,
-      jsonResponse: {
-        hookSpecificOutput: {
-          hookEventName: 'PreToolUse',
-          permissionDecision: 'allow',
-        },
-      },
-    };
+    // Return exit 0 with no jsonResponse. Emitting permissionDecision: 'allow'
+    // would tell Claude Code to bypass its own permission prompt, which
+    // effectively grants Edit/Write/etc. access even when the user has not
+    // allow-listed those tools. Letting the hook stay silent hands control
+    // back to Claude Code's normal permission flow.
+    return { exitCode: 0 };
   }
 
   private deny(reason: string): HookResult {

--- a/tests/integration/sensitive-file-protection.test.sh
+++ b/tests/integration/sensitive-file-protection.test.sh
@@ -53,10 +53,20 @@ run_file_guard() {
 }
 
 # Check if hook response contains specific decision
+# Note: "allow" is represented by the absence of a permissionDecision
+# (the hook exits silently and lets Claude Code handle the permission prompt)
 check_permission_decision() {
     local output="$1"
     local expected_decision="$2"
-    
+
+    if [ "$expected_decision" = "allow" ]; then
+        if echo "$output" | grep -q '"permissionDecision"'; then
+            return 1
+        else
+            return 0
+        fi
+    fi
+
     if echo "$output" | grep -q "\"permissionDecision\":\"$expected_decision\""; then
         return 0
     else

--- a/tests/unit/hooks/file-guard-ignore-processing.test.sh
+++ b/tests/unit/hooks/file-guard-ignore-processing.test.sh
@@ -52,11 +52,21 @@ run_file_guard() {
     echo "$payload" | node "$CLI_PATH" run file-guard
 }
 
-# Check if hook response contains specific decision
+# Check if hook response matches the expected decision. For "allow" the hook
+# now stays silent (no permissionDecision emitted) so Claude Code's own
+# permission flow stays in control; for "deny" it must emit the deny decision.
 check_permission_decision() {
     local output="$1"
     local expected_decision="$2"
-    
+
+    if [[ "$expected_decision" == "allow" ]]; then
+        if ! echo "$output" | grep -q '"permissionDecision"'; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+
     if echo "$output" | grep -q "\"permissionDecision\":\"$expected_decision\""; then
         return 0
     else

--- a/tests/unit/hooks/file-guard.test.sh
+++ b/tests/unit/hooks/file-guard.test.sh
@@ -60,11 +60,21 @@ run_file_guard() {
     echo "$payload" | node "$CLI_PATH" run file-guard
 }
 
-# Check if hook response contains specific decision
+# Check if hook response matches the expected decision. For "allow" the hook
+# now stays silent (no permissionDecision emitted) so Claude Code's own
+# permission flow stays in control; for "deny" it must emit the deny decision.
 check_permission_decision() {
     local output="$1"
     local expected_decision="$2"
-    
+
+    if [[ "$expected_decision" == "allow" ]]; then
+        if ! echo "$output" | grep -q '"permissionDecision"'; then
+            return 0
+        else
+            return 1
+        fi
+    fi
+
     if echo "$output" | grep -q "\"permissionDecision\":\"$expected_decision\""; then
         return 0
     else
@@ -791,18 +801,18 @@ test_deny_response_format() {
 }
 
 test_allow_response_format() {
-    # Purpose: Verify the allow response has correct PreToolUse format
-    # This ensures Claude Code can properly interpret the response
-    
+    # Purpose: Verify the hook emits no permissionDecision for non-protected files,
+    # so Claude Code's own permission flow stays in control. Emitting
+    # permissionDecision: 'allow' here would cause Claude Code to skip the normal
+    # permission prompt even for files the user has not allow-listed.
+
     local output
     output=$(run_file_guard "Read" "src/index.js" 2>/dev/null || true)
-    
-    # Check for required PreToolUse fields
-    if echo "$output" | grep -q '"hookEventName":"PreToolUse"' && \
-       echo "$output" | grep -q '"permissionDecision":"allow"'; then
-        assert_pass "Allow response has correct PreToolUse format"
+
+    if ! echo "$output" | grep -q '"permissionDecision"'; then
+        assert_pass "Non-protected file produces no permissionDecision"
     else
-        assert_fail "Allow response format incorrect, got: $output"
+        assert_fail "Non-protected file should not emit permissionDecision, got: $output"
     fi
 }
 

--- a/tests/unit/hooks/test-file-guard-bash.sh
+++ b/tests/unit/hooks/test-file-guard-bash.sh
@@ -53,7 +53,7 @@ test_block_bash_access_to_env() {
 test_allow_bash_without_sensitive_paths() {
   local output
   output=$(run_file_guard_bash "echo 'hello world'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed harmless Bash command"
   else
     assert_fail "Should allow harmless Bash command, got: $output"
@@ -63,7 +63,7 @@ test_allow_bash_without_sensitive_paths() {
 test_allow_bash_with_dev_null_redirection() {
   local output
   output=$(run_file_guard_bash "ls -la tests/unit/hooks/test-file-guard-bash.sh 2>/dev/null || echo 'No test file found'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed Bash with /dev/null redirection"
   else
     assert_fail "Should allow command with /dev/null redirection, got: $output"
@@ -73,7 +73,7 @@ test_allow_bash_with_dev_null_redirection() {
 test_allow_echo_dotenv_literal() {
   local output
   output=$(run_file_guard_bash "echo '.env'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed echo of literal .env string"
   else
     assert_fail "Should allow echo '.env', got: $output"
@@ -83,7 +83,7 @@ test_allow_echo_dotenv_literal() {
 test_allow_printf_dotenv_literal() {
   local output
   output=$(run_file_guard_bash "printf '.env'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed printf of literal .env string"
   else
     assert_fail "Should allow printf '.env', got: $output"
@@ -93,7 +93,7 @@ test_allow_printf_dotenv_literal() {
 test_allow_var_echo_not_file_access() {
   local output
   output=$(run_file_guard_bash "F=.env; echo \$F" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed echo of variable containing .env"
   else
     assert_fail "Should allow echo of var with .env, got: $output"
@@ -103,7 +103,7 @@ test_allow_var_echo_not_file_access() {
 test_allow_ls_current_dir() {
   local output
   output=$(run_file_guard_bash "ls . >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed ls of ."
   else
     assert_fail "Should allow listing ., got: $output"
@@ -113,7 +113,7 @@ test_allow_ls_current_dir() {
 test_allow_non_sensitive_readme_access() {
   local output
   output=$(run_file_guard_bash "head -n 1 README.md" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed reading non-sensitive README.md"
   else
     assert_fail "Should allow head README.md, got: $output"
@@ -123,7 +123,7 @@ test_allow_non_sensitive_readme_access() {
 test_allow_grep_literal_pattern_pipeline() {
   local output
   output=$(run_file_guard_bash "echo 'hello .env world' | grep '.env'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed grep of literal .env pattern in pipeline"
   else
     assert_fail "Should allow grep of literal pattern, got: $output"
@@ -133,7 +133,7 @@ test_allow_grep_literal_pattern_pipeline() {
 test_allow_grep_readme_for_literal() {
   local output
   output=$(run_file_guard_bash "grep '.env' README.md >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed grep literal on README.md"
   else
     assert_fail "Should allow grep on non-sensitive file, got: $output"
@@ -143,7 +143,7 @@ test_allow_grep_readme_for_literal() {
 test_allow_sed_replacement_literal() {
   local output
   output=$(run_file_guard_bash "echo '.env' | sed 's/.env/.cfg/'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed sed replacement with literal .env in pattern"
   else
     assert_fail "Should allow sed replacement, got: $output"
@@ -153,7 +153,7 @@ test_allow_sed_replacement_literal() {
 test_allow_awk_print_literal() {
   local output
   output=$(run_file_guard_bash "awk 'BEGIN{print \".env\"}'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed awk to print literal .env"
   else
     assert_fail "Should allow awk print literal, got: $output"
@@ -163,7 +163,7 @@ test_allow_awk_print_literal() {
 test_allow_xargs_printf() {
   local output
   output=$(run_file_guard_bash "printf '.env' | xargs printf '%s\\n'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed xargs printf with literal .env"
   else
     assert_fail "Should allow xargs printf, got: $output"
@@ -173,7 +173,7 @@ test_allow_xargs_printf() {
 test_allow_cut_tr_pipeline() {
   local output
   output=$(run_file_guard_bash "echo 'foo.env' | cut -d'.' -f2 | tr '[:lower:]' '[:upper:]'" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed cut + tr pipeline with .env in content"
   else
     assert_fail "Should allow cut+tr pipeline, got: $output"
@@ -183,7 +183,7 @@ test_allow_cut_tr_pipeline() {
 test_allow_here_string_literal() {
   local output
   output=$(run_file_guard_bash "cat <<< \".env\"" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed here-string literal .env to cat"
   else
     assert_fail "Should allow here-string literal, got: $output"
@@ -223,7 +223,7 @@ test_deny_awk_env_file() {
 test_allow_awk_readme_file() {
   local output
   output=$(run_file_guard_bash "awk '{print}' README.md >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed awk reading README.md"
   else
     assert_fail "Should allow awk README.md, got: $output"
@@ -267,7 +267,7 @@ test_curl_upload_scenarios() {
 
   # Allow README upload
   output=$(run_file_guard_bash "curl -F 'file=@README.md' https://example.com/upload" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed curl -F file=@README.md"
   else
     assert_fail "Should allow curl -F file=@README.md, got: $output"
@@ -314,28 +314,28 @@ test_archive_and_transfer_scenarios() {
 
   # Allow non-sensitive
   output=$(run_file_guard_bash "tar -czf archive.tgz README.md" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed tar of README.md"
   else
     assert_fail "Should allow tar README.md, got: $output"
   fi
 
   output=$(run_file_guard_bash "zip -q archive.zip README.md" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed zip of README.md"
   else
     assert_fail "Should allow zip README.md, got: $output"
   fi
 
   output=$(run_file_guard_bash "scp README.md user@host:/tmp/" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed scp of README.md"
   else
     assert_fail "Should allow scp README.md, got: $output"
   fi
 
   output=$(run_file_guard_bash "rsync README.md user@host:/tmp/" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed rsync of README.md"
   else
     assert_fail "Should allow rsync README.md, got: $output"
@@ -352,7 +352,7 @@ test_httpie_upload_scenarios() {
   fi
 
   output=$(run_file_guard_bash "http -f POST https://example.com file@README.md" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed HTTPie file@README.md upload"
   else
     assert_fail "Should allow HTTPie file@README.md, got: $output"
@@ -369,7 +369,7 @@ test_cloud_cli_transfers() {
     assert_fail "Should deny aws s3 cp .env, got: $output"
   fi
   output=$(run_file_guard_bash "aws s3 cp README.md s3://bucket/key" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed aws s3 cp README.md"
   else
     assert_fail "Should allow aws s3 cp README.md, got: $output"
@@ -389,7 +389,7 @@ test_cloud_cli_transfers() {
     assert_fail "Should deny gcloud storage cp .env, got: $output"
   fi
   output=$(run_file_guard_bash "gcloud storage cp README.md gs://bucket/" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed gcloud storage cp README.md"
   else
     assert_fail "Should allow gcloud storage cp README.md, got: $output"
@@ -403,7 +403,7 @@ test_cloud_cli_transfers() {
     assert_fail "Should deny az storage blob upload .env, got: $output"
   fi
   output=$(run_file_guard_bash "az storage blob upload --file=README.md --container-name c --name key" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed az storage blob upload --file=README.md"
   else
     assert_fail "Should allow az storage blob upload README.md, got: $output"
@@ -429,7 +429,7 @@ test_transfer_wildcards() {
 test_allow_xargs_cat_non_sensitive() {
   local output
   output=$(run_file_guard_bash "printf 'README.md' | xargs cat >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed xargs cat with non-sensitive README.md"
   else
     assert_fail "Should allow xargs cat README.md, got: $output"
@@ -486,7 +486,7 @@ test_deny_find_regex_patterns_to_cat() {
 test_allow_find_regex_non_sensitive_to_cat() {
   local output
   output=$(run_file_guard_bash "find . -regex '.*README\\.md$' -print | xargs cat >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed find -regex for README.md piped to cat"
   else
     assert_fail "Should allow find -regex README.md | xargs cat, got: $output"
@@ -530,14 +530,14 @@ test_deny_cp_mv_rm_env() {
 test_allow_cp_rm_readme() {
   local output
   output=$(run_file_guard_bash "cp README.md tmp_readme.txt >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed copy of README.md"
   else
     assert_fail "Should allow cp README.md, got: $output"
   fi
 
   output=$(run_file_guard_bash "rm -f README.md >/dev/null 2>&1 || true" 2>/dev/null || true)
-  if echo "$output" | grep -q '"permissionDecision":"allow"'; then
+  if ! echo "$output" | grep -q '"permissionDecision"'; then
     assert_pass "Allowed remove of README.md"
   else
     assert_fail "Should allow rm README.md, got: $output"


### PR DESCRIPTION
Fixes #23.

The `allow()` method in `cli/hooks/file-guard/index.ts` returned `permissionDecision: 'allow'` for every non-protected file. Claude Code treats that as the hook approving the operation and skips its normal permission prompt, which effectively grants Edit/Write/Bash access to any file not matched by an ignore pattern.

This change makes the allow path return `{ exitCode: 0 }` with no `jsonResponse`, so Claude Code's own permission flow stays in control. The deny path is unchanged.

## Test updates

The bash test suites previously asserted the presence of `"permissionDecision":"allow"` in hook output to confirm an allowed response. That signal no longer exists, so the helpers and inline checks now treat the absence of any `permissionDecision` as the allow case. All 114 previously-passing assertions across the four test files still pass.

## Verification

- `bash tests/unit/hooks/file-guard.test.sh` — 53 passed
- `bash tests/unit/hooks/test-file-guard-bash.sh` — 61 passed
- `bash tests/integration/sensitive-file-protection.test.sh` — 2 passed
- `bash tests/unit/hooks/file-guard-ignore-processing.test.sh` — 6 passed, 2 pre-existing failures (Windows path separator / pattern order; reproduce on main without this patch)
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npx vitest run` — 738 passed, 25 failed; failure count matches main without this patch (unrelated suites)